### PR TITLE
Nano Experiments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
 
 option(OCIO_LUT_SUPPORT "Specify wheter to build with LUT and file-transform support. Requies Expat dependency" ON)
 option(OCIO_ARCHIVE_SUPPORT "Specify whether to build with OCIOZ archive support. Requires ZLIB dependency " ON)
+option(OCIO_USE_HALF_LOOKUP_TABLE "Determines if the imath library should 64k LUT for half conversions." ON)
 
 set (OCIO_PYTHON_VERSION "" CACHE STRING
      "Preferred Python version (if any) in case multiple are available")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ option(OCIO_BUILD_FROZEN_DOCS "Specify whether to build frozen documentation, ne
 option(OCIO_BUILD_DOCS "Specify whether to build documentation" ${OCIO_BUILD_FROZEN_DOCS})
 
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
+
+option(OCIO_LUT_SUPPORT "Specify wheter to build with LUT and file-transform support. Requies Expat dependency" ON)
+option(OCIO_ARCHIVE_SUPPORT "Specify whether to build with OCIOZ archive support. Requires ZLIB dependency " ON)
+
 set (OCIO_PYTHON_VERSION "" CACHE STRING
      "Preferred Python version (if any) in case multiple are available")
 

--- a/include/OpenColorIO/OpenColorABI.h.in
+++ b/include/OpenColorIO/OpenColorABI.h.in
@@ -26,6 +26,9 @@
 #define OCIO_VERSION_MAJOR @OpenColorIO_VERSION_MAJOR@
 #define OCIO_VERSION_MINOR @OpenColorIO_VERSION_MINOR@
 
+// Experimental switches to streamline OCIO library.
+#cmakedefine01  OCIO_LUT_SUPPORT
+#cmakedefine01  OCIO_ARCHIVE_SUPPORT
 
 // Highlight deprecated methods or classes.
 #if defined(_MSC_VER)

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -228,6 +228,7 @@ extern OCIOEXPORT void SetCurrentConfig(const ConstConfigRcPtr & config);
  */
 extern OCIOEXPORT const char * ResolveConfigPath(const char * originalPath) noexcept;
 
+#if OCIO_ARCHIVE_SUPPORT
 /**
  * \brief Extract an OCIO Config archive.
  * 
@@ -247,6 +248,7 @@ extern OCIOEXPORT void ExtractOCIOZArchive(
     const char * archivePath, 
     const char * destinationDir
 );
+#endif //OCIO_ARCHIVE_SUPPORT
 
 /**
  * \brief
@@ -1480,6 +1482,7 @@ public:
     void setConfigIOProxy(ConfigIOProxyRcPtr ciop);
     ConfigIOProxyRcPtr getConfigIOProxy() const;
 
+#if OCIO_ARCHIVE_SUPPORT
     /**
      * \brief Verify if the config is archivable.
      *
@@ -1530,6 +1533,7 @@ public:
      * \param ostream The output stream to write to.
      */
     void archive(std::ostream & ostream) const;
+#endif //OCIO_ARCHIVE_SUPPORT
 
     Config(const Config &) = delete;
     Config& operator= (const Config &) = delete;
@@ -2761,7 +2765,7 @@ private:
 };
 
 
-
+#if OCIO_LUT_SUPPORT
 /**
  * In certain situations it is necessary to serialize transforms into a variety
  * of application specific LUT formats. Note that not all file formats that may
@@ -2893,6 +2897,7 @@ private:
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
 };
+#endif //OCIO_LUT_SUPPORT
 
 
 ///////////////////////////////////////////////////////////////////////////
@@ -3206,6 +3211,7 @@ public:
     /// End to collect the shader data.
     virtual void end();
 
+#if OCIO_LUT_SUPPORT
     /// Some graphic cards could have 1D & 2D textures with size limitations.
     virtual void setTextureMaxWidth(unsigned maxWidth) = 0;
     virtual unsigned getTextureMaxWidth() const noexcept = 0;
@@ -3213,6 +3219,7 @@ public:
     /// Allow 1D GPU resource type, otherwise always using 2D resources for 1D LUTs.
     virtual void setAllowTexture1D(bool allowed) = 0;
     virtual bool getAllowTexture1D() const = 0;
+#endif //OCIO_LUT_SUPPORT
 
     /**
      * To avoid global texture sampler and uniform name clashes always append an increasing index
@@ -3264,6 +3271,7 @@ public:
      */
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 
+#if OCIO_LUT_SUPPORT
     enum TextureType
     {
         TEXTURE_RED_CHANNEL, ///< Only need a red channel texture
@@ -3306,6 +3314,7 @@ public:
                               unsigned edgelen,
                               Interpolation interpolation,
                               const float * values) = 0;
+#endif //OCIO_LUT_SUPPORT
 
     // Methods to specialize parts of a OCIO shader program
     virtual void addToDeclareShaderCode(const char * shaderCode);
@@ -3533,6 +3542,7 @@ public:
     /// Returns name of uniform and data as parameter.
     virtual const char * getUniform(unsigned index, UniformData & data) const = 0;
 
+#if OCIO_LUT_SUPPORT
     // 1D lut related methods
     virtual unsigned getNumTextures() const noexcept = 0;
     virtual void getTexture(unsigned index,
@@ -3553,6 +3563,7 @@ public:
                               unsigned & edgelen,
                               Interpolation & interpolation) const = 0;
     virtual void get3DTextureValues(unsigned index, const float *& values) const = 0;
+#endif //OCIO_LUT_SUPPORT
 
     /// Get the complete OCIO shader program.
     const char * getShaderText() const noexcept;

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -141,6 +141,7 @@ protected:
     Transform() = default;
 };
 
+// TODO: this operator can just call virtual print function, which will simplify things a lot. /coz 2024-04-16
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Transform&);
 
 
@@ -226,7 +227,7 @@ private:
 //
 extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const BuiltinTransform &) noexcept;
 
-
+#if OCIO_LUT_SUPPORT
 /**
  * \brief 
  *     An implementation of the ASC Color Decision List (CDL), based on the ASC v1.2
@@ -328,6 +329,7 @@ protected:
 };
 
 extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const CDLTransform &);
+#endif //OCIO_LUT_SUPPORT
 
 
 class OCIOEXPORT ColorSpaceTransform : public Transform
@@ -1022,7 +1024,7 @@ private:
 extern OCIOEXPORT std::ostream & operator<<(std::ostream &,
                                             const ExposureContrastTransform &);
 
-
+#if OCIO_LUT_SUPPORT
 class OCIOEXPORT FileTransform : public Transform
 {
 public:
@@ -1095,6 +1097,7 @@ private:
 };
 
 extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FileTransform &);
+#endif //OCIO_LUT_SUPPORT
 
 
 /**
@@ -1608,7 +1611,7 @@ private:
 
 extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LookTransform &);
 
-
+#if OCIO_LUT_SUPPORT
 /// Represents a 1D-LUT transform.
 class OCIOEXPORT Lut1DTransform : public Transform
 {
@@ -1785,6 +1788,8 @@ protected:
 };
 
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Lut3DTransform&);
+#endif //OCIO_LUT_SUPPORT
+
 
 /**
  * Represents an MX+B Matrix transform.

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -7,6 +7,10 @@
 
 #include "OpenColorABI.h"
 
+#define OCIO_LUT_SUPPORT 0
+#define OCIO_ARCHIVE_SUPPORT 0
+
+
 #ifndef OCIO_NAMESPACE
 #error This header cannot be used directly. Use <OpenColorIO/OpenColorIO.h> instead.
 #endif
@@ -179,9 +183,11 @@ class OCIOEXPORT ExposureContrastTransform;
 typedef OCIO_SHARED_PTR<const ExposureContrastTransform> ConstExposureContrastTransformRcPtr;
 typedef OCIO_SHARED_PTR<ExposureContrastTransform> ExposureContrastTransformRcPtr;
 
+#if OCIO_LUT_SUPPORT
 class OCIOEXPORT FileTransform;
 typedef OCIO_SHARED_PTR<const FileTransform> ConstFileTransformRcPtr;
 typedef OCIO_SHARED_PTR<FileTransform> FileTransformRcPtr;
+#endif //OCIO_LUT_SUPPORT
 
 class OCIOEXPORT FixedFunctionTransform;
 typedef OCIO_SHARED_PTR<const FixedFunctionTransform> ConstFixedFunctionTransformRcPtr;
@@ -219,6 +225,7 @@ class OCIOEXPORT LogTransform;
 typedef OCIO_SHARED_PTR<const LogTransform> ConstLogTransformRcPtr;
 typedef OCIO_SHARED_PTR<LogTransform> LogTransformRcPtr;
 
+#if OCIO_LUT_SUPPORT
 class OCIOEXPORT Lut1DTransform;
 typedef OCIO_SHARED_PTR<const Lut1DTransform> ConstLut1DTransformRcPtr;
 typedef OCIO_SHARED_PTR<Lut1DTransform> Lut1DTransformRcPtr;
@@ -226,6 +233,7 @@ typedef OCIO_SHARED_PTR<Lut1DTransform> Lut1DTransformRcPtr;
 class OCIOEXPORT Lut3DTransform;
 typedef OCIO_SHARED_PTR<const Lut3DTransform> ConstLut3DTransformRcPtr;
 typedef OCIO_SHARED_PTR<Lut3DTransform> Lut3DTransformRcPtr;
+#endif //OCIO_LUT_SUPPORT
 
 class OCIOEXPORT MatrixTransform;
 typedef OCIO_SHARED_PTR<const MatrixTransform> ConstMatrixTransformRcPtr;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -7,10 +7,6 @@
 
 #include "OpenColorABI.h"
 
-#define OCIO_LUT_SUPPORT 0
-#define OCIO_ARCHIVE_SUPPORT 0
-
-
 #ifndef OCIO_NAMESPACE
 #error This header cannot be used directly. Use <OpenColorIO/OpenColorIO.h> instead.
 #endif

--- a/src/OpenColorIO/Baker.cpp
+++ b/src/OpenColorIO/Baker.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 
 #include <iostream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "transforms/FileTransform.h"
 #include "BakingUtils.h"
@@ -414,3 +415,4 @@ void Baker::bake(std::ostream & os) const
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/BakingUtils.cpp
+++ b/src/OpenColorIO/BakingUtils.cpp
@@ -3,6 +3,8 @@
 
 #include "BakingUtils.h"
 
+#if OCIO_LUT_SUPPORT
+
 namespace OCIO_NAMESPACE
 {
 
@@ -131,3 +133,4 @@ void GetTargetRange(const Baker & baker, float& start, float& end)
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -221,6 +221,10 @@ if(OCIO_USE_SIMD AND (OCIO_ARCH_X86 OR OCIO_USE_SSE2NEON))
     set_property(SOURCE ops/lut3d/Lut3DOpCPU_AVX512.cpp APPEND PROPERTY COMPILE_OPTIONS ${OCIO_AVX512_ARGS})
 endif()
 
+if(NOT OCIO_USE_HALF_LOOKUP_TABLE)
+    add_compile_definitions(IMATH_HALF_NO_LOOKUP_TABLE)
+endif()
+
 configure_file(CPUInfoConfig.h.in CPUInfoConfig.h)
 
 add_library(OpenColorIO ${SOURCES})

--- a/src/OpenColorIO/CPUProcessor.cpp
+++ b/src/OpenColorIO/CPUProcessor.cpp
@@ -139,12 +139,15 @@ void CreateCPUEngine(const OpRcPtrVec & ops,
 
         if(idx==0)
         {
+#if OCIO_LUT_SUPPORT
             if(opData->getType()==OpData::Lut1DType)
             {
                 ConstLut1DOpDataRcPtr lut = DynamicPtrCast<const Lut1DOpData>(opData);
                 inBitDepthOp = GetLut1DRenderer(lut, in, BIT_DEPTH_F32);
             }
-            else if(in==BIT_DEPTH_F32)
+            else 
+#endif //OCIO_LUT_SUPPORT
+            if(in==BIT_DEPTH_F32)
             {
                 inBitDepthOp = op->getCPUOp(fastLogExpPow);
             }
@@ -161,12 +164,15 @@ void CreateCPUEngine(const OpRcPtrVec & ops,
         }
         else if(idx==(maxOps-1))
         {
+#if OCIO_LUT_SUPPORT
             if(opData->getType()==OpData::Lut1DType)
             {
                 ConstLut1DOpDataRcPtr lut = DynamicPtrCast<const Lut1DOpData>(opData);
                 outBitDepthOp = GetLut1DRenderer(lut, BIT_DEPTH_F32, out);
             }
-            else if(out==BIT_DEPTH_F32)
+            else 
+#endif //OCIO_LUT_SUPPORT
+            if(out==BIT_DEPTH_F32)
             {
                 outBitDepthOp = op->getCPUOp(fastLogExpPow);
             }

--- a/src/OpenColorIO/Caching.cpp
+++ b/src/OpenColorIO/Caching.cpp
@@ -24,6 +24,9 @@ const char * OCIO_DISABLE_CACHE_FALLBACK   = "OCIO_DISABLE_CACHE_FALLBACK";
 void ClearAllCaches()
 {
     ClearPathCaches();
+#if OCIO_LUT_SUPPORT
     ClearFileTransformCaches();
+#endif //OCIO_LUT_SUPPORT
+
 }
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ConfigUtils.cpp
+++ b/src/OpenColorIO/ConfigUtils.cpp
@@ -326,7 +326,7 @@ bool containsBlockedTransform(const ConstTransformRcPtr & transform)
             }
         }
     }
-
+#if OCIO_LUT_SUPPORT
     // Prevent FileTransforms from being used, except for spi1d and spimtx since these
     // may be used with OCIO v1 configs to implement the type of color spaces the heuristics
     // are designed to look for.  (E.g. The sRGB Texture space in the legacy ACES configs.)
@@ -342,6 +342,7 @@ bool containsBlockedTransform(const ConstTransformRcPtr & transform)
             return true;
         }
     }
+#endif //OCIO_LUT_SUPPORT
 
     // Prevent transforms that may be hiding a FileTransform.
     else if (transform->getTransformType() == TRANSFORM_TYPE_COLORSPACE

--- a/src/OpenColorIO/ContextVariableUtils.cpp
+++ b/src/OpenColorIO/ContextVariableUtils.cpp
@@ -178,10 +178,12 @@ bool CollectContextVariables(const Config & config,
     {
         if (CollectContextVariables(config, context, *tr, usedContextVars)) return true;
     }
+#if OCIO_LUT_SUPPORT
     else if(ConstFileTransformRcPtr tr = DynamicPtrCast<const FileTransform>(transform))
     {
         if (CollectContextVariables(config, context, *tr, usedContextVars)) return true;
     }
+#endif OCIO_LUT_SUPPORT
     else if(ConstGroupTransformRcPtr tr = DynamicPtrCast<const GroupTransform>(transform))
     {
         if (CollectContextVariables(config, context, *tr, usedContextVars)) return true;

--- a/src/OpenColorIO/ContextVariableUtils.h
+++ b/src/OpenColorIO/ContextVariableUtils.h
@@ -70,11 +70,12 @@ bool CollectContextVariables(const Config & config,
                              const Context & context,
                              const DisplayViewTransform & tr,
                              ContextRcPtr & usedContextVars);
-
+#if OCIO_LUT_SUPPORT
 bool CollectContextVariables(const Config & config, 
                              const Context & context,
                              const FileTransform & tr,
                              ContextRcPtr & usedContextVars);
+#endif //OCIO_LUT_SUPPORT
 
 bool CollectContextVariables(const Config & config, 
                              const Context & context,

--- a/src/OpenColorIO/GpuShader.cpp
+++ b/src/OpenColorIO/GpuShader.cpp
@@ -19,7 +19,7 @@ namespace OCIO_NAMESPACE
 
 namespace
 {
-
+#if OCIO_LUT_SUPPORT
 static void  CreateArray(const float * buf,
                          unsigned w, unsigned h, unsigned d,
                          GpuShaderDesc::TextureType type,
@@ -35,6 +35,8 @@ static void  CreateArray(const float * buf,
     res.resize(size);
     std::memcpy(&res[0], buf, size * sizeof(float));
 }
+#endif //OCIO_LUT_SUPPORT
+
 }
 
 namespace GPUShaderImpl
@@ -43,6 +45,7 @@ namespace GPUShaderImpl
 class PrivateImpl
 {
 public:
+#if OCIO_LUT_SUPPORT
     struct Texture
     {
         Texture(const char * textureName,
@@ -101,6 +104,7 @@ public:
     };
 
     typedef std::vector<Texture> Textures;
+#endif //OCIO_LUT_SUPPORT
 
     struct Uniform
     {
@@ -167,6 +171,7 @@ public:
 
     virtual ~PrivateImpl() {}
 
+#if OCIO_LUT_SUPPORT
     inline unsigned get3dLutMaxLength() const { return Lut3DOpData::maxSupportedLength; }
 
     inline unsigned get1dLutMaxWidth() const { return m_max1DLUTWidth; }
@@ -297,6 +302,7 @@ public:
         const Texture & t = m_textures3D[index];
         values = &t.m_values[0];
     }
+#endif //OCIO_LUT_SUPPORT
 
     unsigned getNumUniforms() const
     {
@@ -374,8 +380,10 @@ public:
         m_uniforms.emplace_back(name, getSize, getVectorInt);
         return true;
     }
+#if OCIO_LUT_SUPPORT
     Textures m_textures;
     Textures m_textures3D;
+#endif //OCIO_LUT_SUPPORT
     Uniforms m_uniforms;
 
 private:
@@ -459,7 +467,7 @@ bool GenericGpuShaderDesc::addUniform(const char * name,
     return getImplGeneric()->addUniform(name, getSize, getVectorInt);
 }
 
-
+#if OCIO_LUT_SUPPORT
 unsigned GenericGpuShaderDesc::getTextureMaxWidth() const noexcept
 {
     return getImplGeneric()->get1dLutMaxWidth();
@@ -539,6 +547,8 @@ void GenericGpuShaderDesc::get3DTextureValues(unsigned index, const float *& val
 {
     getImplGeneric()->get3DTextureValues(index, values);
 }
+#endif //OCIO_LUT_SUPPORT
+
 
 void GenericGpuShaderDesc::Deleter(GenericGpuShaderDesc* c)
 {

--- a/src/OpenColorIO/GpuShader.h
+++ b/src/OpenColorIO/GpuShader.h
@@ -26,11 +26,14 @@ class GenericGpuShaderDesc : public GpuShaderDesc
 public:
     static GpuShaderDescRcPtr Create();
 
+#if OCIO_LUT_SUPPORT
+
     unsigned getTextureMaxWidth() const noexcept override;
     void setTextureMaxWidth(unsigned maxWidth) override;
 
     bool getAllowTexture1D() const noexcept override;
     void setAllowTexture1D(bool allowed) override;
+#endif //OCIO_LUT_SUPPORT
 
     // Accessors to the uniforms
     //
@@ -45,7 +48,7 @@ public:
     bool addUniform(const char * name,
                     const SizeGetter & getSize,
                     const VectorIntGetter & getVectorInt) override;
-
+#if OCIO_LUT_SUPPORT
     // Accessors to the 1D & 2D textures built from 1D LUT
     //
     unsigned getNumTextures() const noexcept override;
@@ -79,6 +82,7 @@ public:
                       unsigned & edgelen,
                       Interpolation & interpolation) const override;
     void get3DTextureValues(unsigned index, const float *& value) const override;
+#endif //OCIO_LUT_SUPPORT
 
 private:
 

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -556,6 +556,7 @@ inline void save(YAML::Emitter & out, const ConstBuiltinTransformRcPtr & t)
     out << YAML::EndMap;
 }
 
+#if OCIO_LUT_SUPPORT
 // CDLTransform
 
 inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
@@ -687,6 +688,7 @@ inline void save(YAML::Emitter& out, ConstCDLTransformRcPtr t, unsigned int majo
     EmitBaseTransformKeyValues(out, t);
     out << YAML::EndMap;
 }
+#endif //OCIO_LUT_SUPPORT
 
 // ColorSpaceTransform
 
@@ -1246,6 +1248,8 @@ inline void save(YAML::Emitter& out, ConstExposureContrastTransformRcPtr t)
     out << YAML::EndMap;
 }
 
+#if OCIO_LUT_SUPPORT
+
 // FileTransform
 
 inline void load(const YAML::Node& node, FileTransformRcPtr& t)
@@ -1330,6 +1334,7 @@ inline void save(YAML::Emitter& out, ConstFileTransformRcPtr t, unsigned int maj
     EmitBaseTransformKeyValues(out, t);
     out << YAML::EndMap;
 }
+#endif //OCIO_LUT_SUPPORT
 
 // FixedFunctionTransform
 
@@ -2946,12 +2951,14 @@ void load(const YAML::Node& node, TransformRcPtr& t)
         load(node, temp);
         t = temp;
     }
+#if OCIO_LUT_SUPPORT
     else if(type == "CDLTransform")
     {
         CDLTransformRcPtr temp;
         load(node, temp);
         t = temp;
     }
+#endif //OCIO_LUT_SUPPORT
     else if(type == "ColorSpaceTransform")
     {
         ColorSpaceTransformRcPtr temp;
@@ -2982,12 +2989,16 @@ void load(const YAML::Node& node, TransformRcPtr& t)
         load(node, temp);
         t = temp;
     }
+#if OCIO_LUT_SUPPORT
+
     else if(type == "FileTransform")
     {
         FileTransformRcPtr temp;
         load(node, temp);
         t = temp;
     }
+#endif //OCIO_LUT_SUPPORT
+
     else if(type == "FixedFunctionTransform")
     {
         FixedFunctionTransformRcPtr temp;
@@ -3080,9 +3091,11 @@ void save(YAML::Emitter& out, ConstTransformRcPtr t, unsigned int majorVersion)
     else if (ConstBuiltinTransformRcPtr builtin_tran = \
         DynamicPtrCast<const BuiltinTransform>(t))
         save(out, builtin_tran);
+#if OCIO_LUT_SUPPORT
     else if(ConstCDLTransformRcPtr CDL_tran = \
         DynamicPtrCast<const CDLTransform>(t))
         save(out, CDL_tran, majorVersion);
+#endif //OCIO_LUT_SUPPORT
     else if(ConstColorSpaceTransformRcPtr ColorSpace_tran = \
         DynamicPtrCast<const ColorSpaceTransform>(t))
         save(out, ColorSpace_tran);
@@ -3095,9 +3108,11 @@ void save(YAML::Emitter& out, ConstTransformRcPtr t, unsigned int majorVersion)
     else if (ConstExponentWithLinearTransformRcPtr ExpLinear_tran = \
         DynamicPtrCast<const ExponentWithLinearTransform>(t))
         save(out, ExpLinear_tran);
+#if OCIO_LUT_SUPPORT
     else if(ConstFileTransformRcPtr File_tran = \
         DynamicPtrCast<const FileTransform>(t))
         save(out, File_tran, majorVersion);
+#endif OCIO_LUT_SUPPORT
     else if (ConstExposureContrastTransformRcPtr File_tran = \
         DynamicPtrCast<const ExposureContrastTransform>(t))
         save(out, File_tran);

--- a/src/OpenColorIO/OCIOZArchive.cpp
+++ b/src/OpenColorIO/OCIOZArchive.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_ARCHIVE_SUPPORT
 
 #include <sstream>
 #include <fstream>
@@ -10,7 +12,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Mutex.h"
 #include "Platform.h"
@@ -652,3 +653,5 @@ void CIOPOciozArchive::buildEntries()
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_ARCHIVE_SUPPORT

--- a/src/OpenColorIO/OCIOZArchive.h
+++ b/src/OpenColorIO/OCIOZArchive.h
@@ -5,13 +5,16 @@
 #ifndef INCLUDED_OCIO_ARCHIVEUTILS_H
 #define INCLUDED_OCIO_ARCHIVEUTILS_H
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_ARCHIVE_SUPPORT
+
 #include <sstream>
 #include <fstream>
 #include <vector>
 #include <map>
 #include <string>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 namespace OCIO_NAMESPACE
 {
@@ -108,4 +111,5 @@ private:
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_ARCHIVE_SUPPORT
 #endif

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -488,9 +488,11 @@ void CreateOpVecFromOpData(OpRcPtrVec & ops,
     {
     case OpData::CDLType:
     {
+#if OCIO_LUT_SUPPORT
         auto cdlSrc = std::dynamic_pointer_cast<const CDLOpData>(opData);
         auto cdl = std::make_shared<CDLOpData>(*cdlSrc);
         CreateCDLOp(ops, cdl, dir);
+#endif //OCIO_LUT_SUPPORT
         break;
     }
 
@@ -558,6 +560,7 @@ void CreateOpVecFromOpData(OpRcPtrVec & ops,
         break;
     }
 
+#if OCIO_LUT_SUPPORT 
     case OpData::Lut1DType:
     {
         auto lutSrc = std::dynamic_pointer_cast<const Lut1DOpData>(opData);
@@ -573,6 +576,12 @@ void CreateOpVecFromOpData(OpRcPtrVec & ops,
         CreateLut3DOp(ops, lut, dir);
         break;
     }
+#else
+    case OpData::Lut1DType:
+	case OpData::Lut3DType:
+        throw Exception("LUT support is not enabled in this build");
+        break;
+#endif //OCIO_LUT_SUPPORT
 
     case OpData::MatrixType:
     {

--- a/src/OpenColorIO/OpBuilders.h
+++ b/src/OpenColorIO/OpBuilders.h
@@ -83,12 +83,13 @@ void BuildExponentWithLinearOp(OpRcPtrVec & ops,
 void BuildExposureContrastOp(OpRcPtrVec & ops,
                              const ExposureContrastTransform & transform,
                              TransformDirection dir);
-
+#if OCIO_LUT_SUPPORT
 void BuildFileTransformOps(OpRcPtrVec & ops,
                            const Config & config,
                            const ConstContextRcPtr & context,
                            const FileTransform & transform,
                            TransformDirection dir);
+#endif //OCIO_LUT_SUPPORT
 
 void BuildFixedFunctionOp(OpRcPtrVec & ops,
                           const FixedFunctionTransform & transform,
@@ -142,7 +143,7 @@ void BuildLookOps(OpRcPtrVec & ops,
                   const Config & config,
                   const ConstContextRcPtr & context,
                   const LookParseResult & looks);
-
+#if OCIO_LUT_SUPPORT
 void BuildLut1DOp(OpRcPtrVec & ops,
                   const Lut1DTransform & transform,
                   TransformDirection dir);
@@ -150,6 +151,7 @@ void BuildLut1DOp(OpRcPtrVec & ops,
 void BuildLut3DOp(OpRcPtrVec & ops,
                   const Lut3DTransform & transform,
                   TransformDirection dir);
+#endif //OCIO_LUT_SUPPORT
 
 void BuildMatrixOp(OpRcPtrVec & ops,
                    const MatrixTransform & transform,

--- a/src/OpenColorIO/OpOptimizers.cpp
+++ b/src/OpenColorIO/OpOptimizers.cpp
@@ -244,6 +244,7 @@ int RemoveInverseOps(OpRcPtrVec & opVec, OptimizationFlags oFlags)
             // mean inserting a Range to emulate the clamping done by the original ops.
 
             OpRcPtr replacedBy;
+#if OCIO_LUT_SUPPORT
             if (type1 == OpData::Lut1DType)
             {
                 // Lut1D gets special handling so that both halfs of the pair are available.
@@ -270,6 +271,7 @@ int RemoveInverseOps(OpRcPtrVec & opVec, OptimizationFlags oFlags)
                 replacedBy = ops[0];
             }
             else
+#endif //OCIO_LUT_SUPPORT
             {
                 replacedBy = op1->getIdentityReplacement();
             }
@@ -364,6 +366,7 @@ int ReplaceInverseLuts(OpRcPtrVec & opVec)
         ConstOpRcPtr op = opVec[i];
         auto opData = op->data();
         const auto type = opData->getType();
+#if OCIO_LUT_SUPPORT
         if (type == OpData::Lut1DType)
         {
             auto lutData = OCIO_DYNAMIC_POINTER_CAST<const Lut1DOpData>(opData);
@@ -390,6 +393,8 @@ int ReplaceInverseLuts(OpRcPtrVec & opVec)
                 ++count;
             }
         }
+#endif //OCIO_LUT_SUPPORT
+
     }
     return count;
 
@@ -481,6 +486,7 @@ unsigned FindSeparablePrefix(const OpRcPtrVec & ops)
     // If the only op is a 1D LUT, there is actually nothing to optimize
     // so set the length to 0.  (This also avoids an infinite loop.)
     // (If it is an inverse 1D LUT, proceed since we want to replace it with a 1D LUT.)
+#if OCIO_LUT_SUPPORT
     if (prefixLen == 1)
     {
         ConstOpRcPtr constOp0 = ops[0];
@@ -494,6 +500,7 @@ unsigned FindSeparablePrefix(const OpRcPtrVec & ops)
             }
         }
     }
+#endif //OCIO_LUT_SUPPORT
 
     // Some ops are so fast that it may not make sense to replace just one of those.
     // E.g., if it's just a single matrix, it may not be faster to replace it with a LUT.
@@ -540,6 +547,7 @@ unsigned FindSeparablePrefix(const OpRcPtrVec & ops)
 // the op list with a single 1D LUT that is built to do a look-up for the input bit-depth.
 void OptimizeSeparablePrefix(OpRcPtrVec & ops, BitDepth in)
 {
+#if OCIO_LUT_SUPPORT
     if (ops.empty())
     {
         return;
@@ -580,6 +588,7 @@ void OptimizeSeparablePrefix(OpRcPtrVec & ops, BitDepth in)
     FinalizeOps(lutOps);
 
     ops.insert(ops.begin(), lutOps.begin(), lutOps.end());
+#endif OCIO_LUT_SUPPORT
 }
 } // namespace
 

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -432,7 +432,7 @@ ConstGPUProcessorRcPtr Processor::Impl::getOptimizedGPUProcessor(OptimizationFla
 ConstGPUProcessorRcPtr Processor::Impl::getOptimizedLegacyGPUProcessor(OptimizationFlags oFlags,
                                                                        unsigned edgelen) const
 {
-
+#if OCIO_LUT_SUPPORT
     OpRcPtrVec gpuOps = m_ops;
 
     {
@@ -471,6 +471,9 @@ ConstGPUProcessorRcPtr Processor::Impl::getOptimizedLegacyGPUProcessor(Optimizat
     }
 
     return getGPUProcessor(gpuOps, oFlags);
+#else
+    throw Exception("LUT support is turned off.");
+#endif //OCIO_LUT_SUPPORT
 }
 
 ConstGPUProcessorRcPtr Processor::Impl::getGPUProcessor(const OpRcPtrVec & gpuOps,

--- a/src/OpenColorIO/Transform.cpp
+++ b/src/OpenColorIO/Transform.cpp
@@ -58,11 +58,13 @@ void BuildOps(OpRcPtrVec & ops,
     {
         BuildBuiltinOps(ops, *builtInTransform, dir);
     }
+#if OCIO_LUT_SUPPORT
     else if(ConstCDLTransformRcPtr cdlTransform = \
         DynamicPtrCast<const CDLTransform>(transform))
     {
         BuildCDLOp(ops, config, *cdlTransform, dir);
     }
+#endif //OCIO_LUT_SUPPORT
     else if(ConstColorSpaceTransformRcPtr colorSpaceTransform = \
         DynamicPtrCast<const ColorSpaceTransform>(transform))
     {
@@ -88,11 +90,13 @@ void BuildOps(OpRcPtrVec & ops,
     {
         BuildExposureContrastOp(ops, *ecTransform, dir);
     }
+#if OCIO_LUT_SUPPORT
     else if(ConstFileTransformRcPtr fileTransform = \
         DynamicPtrCast<const FileTransform>(transform))
     {
         BuildFileTransformOps(ops, config, context, *fileTransform, dir);
     }
+#endif //OCIO_LUT_SUPPORT
     else if (ConstFixedFunctionTransformRcPtr fixedFunctionTransform = \
         DynamicPtrCast<const FixedFunctionTransform>(transform))
     {
@@ -138,6 +142,7 @@ void BuildOps(OpRcPtrVec & ops,
     {
         BuildLookOps(ops, config, context, *lookTransform, dir);
     }
+#if OCIO_LUT_SUPPORT
     else if (ConstLut1DTransformRcPtr lut1dTransform = \
         DynamicPtrCast<const Lut1DTransform>(transform))
     {
@@ -148,6 +153,7 @@ void BuildOps(OpRcPtrVec & ops,
     {
         BuildLut3DOp(ops, *lut3dTransform, dir);
     }
+#endif //OCIO_LUT_SUPPORT
     else if(ConstMatrixTransformRcPtr matrixTransform = \
         DynamicPtrCast<const MatrixTransform>(transform))
     {
@@ -182,11 +188,13 @@ std::ostream& operator<< (std::ostream & os, const Transform & transform)
     {
         os << *builtInTransform;
     }
+#if OCIO_LUT_SUPPORT
     else if(const CDLTransform * cdlTransform = \
         dynamic_cast<const CDLTransform*>(t))
     {
         os << *cdlTransform;
     }
+#endif //OCIO_LUT_SUPPORT
     else if(const ColorSpaceTransform * colorSpaceTransform = \
         dynamic_cast<const ColorSpaceTransform*>(t))
     {
@@ -212,11 +220,13 @@ std::ostream& operator<< (std::ostream & os, const Transform & transform)
     {
         os << *ecTransform;
     }
+#if OCIO_LUT_SUPPORT
     else if(const FileTransform * fileTransform = \
         dynamic_cast<const FileTransform*>(t))
     {
         os << *fileTransform;
     }
+#endif //OCIO_LUT_SUPPORT
     else if(const FixedFunctionTransform * fixedFunctionTransform = \
         dynamic_cast<const FixedFunctionTransform*>(t))
     {
@@ -262,6 +272,7 @@ std::ostream& operator<< (std::ostream & os, const Transform & transform)
     {
         os << *lookTransform;
     }
+#if OCIO_LUT_SUPPORT
     else if (const Lut1DTransform * lut1dTransform = \
         dynamic_cast<const Lut1DTransform*>(t))
     {
@@ -272,6 +283,7 @@ std::ostream& operator<< (std::ostream & os, const Transform & transform)
     {
         os << *lut3dTransform;
     }
+#endif //OCIO_LUT_SUPPORT
     else if(const MatrixTransform * matrixTransform = \
         dynamic_cast<const MatrixTransform*>(t))
     {
@@ -303,12 +315,14 @@ void CreateTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op)
         return;
 
     auto data = op->data();
-
+#if OCIO_LUT_SUPPORT
     if (DynamicPtrCast<const CDLOpData>(data))
     {
         CreateCDLTransform(group, op);
     }
-    else if (DynamicPtrCast<const ExponentOpData>(data))
+    else 
+#endif //OCIO_LUT_SUPPORT
+	if (DynamicPtrCast<const ExponentOpData>(data))
     {
         CreateExponentTransform(group, op);
     }
@@ -340,6 +354,7 @@ void CreateTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op)
     {
         CreateLogTransform(group, op);
     }
+#if OCIO_LUT_SUPPORT //TODO Nano: throw?
     else if (DynamicPtrCast<const Lut1DOpData>(data))
     {
         CreateLut1DTransform(group, op);
@@ -348,6 +363,7 @@ void CreateTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op)
     {
         CreateLut3DTransform(group, op);
     }
+#endif //OCIO_LUT_SUPPORT
     else if (DynamicPtrCast<const MatrixOpData>(data))
     {
         CreateMatrixTransform(group, op);

--- a/src/OpenColorIO/apphelpers/ColorSpaceHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/ColorSpaceHelpers.cpp
@@ -723,8 +723,10 @@ std::ostream & operator<<(std::ostream & os, const ColorSpaceMenuHelper & menu)
 namespace ColorSpaceHelpers
 {
 
+#if OCIO_LUT_SUPPORT
 namespace
 {
+
 void AddColorSpace(ConfigRcPtr & config,
                    ColorSpaceRcPtr & colorSpace,
                    FileTransformRcPtr & userTransform,
@@ -833,6 +835,7 @@ void AddColorSpace(ConfigRcPtr & config,
 
     AddColorSpace(config, *info, file, categories, connectionColorSpaceName);
 }
+#endif //OCIO_LUT_SUPPORT
 
 } // ColorSpaceHelpers
 

--- a/src/OpenColorIO/apphelpers/DisplayViewHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/DisplayViewHelpers.cpp
@@ -375,6 +375,7 @@ void RemoveActiveDisplayView(ConfigRcPtr & config, const char * displayName, con
     }
 }
 
+#if OCIO_LUT_SUPPORT
 void AddDisplayView(ConfigRcPtr & config,
                     const char * displayName,
                     const char * viewName,
@@ -499,6 +500,7 @@ void AddDisplayView(ConfigRcPtr & config,
                    colorSpace, file,
                    connectionColorSpaceName);
 }
+#endif //OCIO_LUT_SUPPORT
 
 void RemoveDisplayView(ConfigRcPtr & config, const char * displayName, const char * viewName)
 {

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "fileformats/FileFormatUtils.h"
@@ -642,3 +645,5 @@ FileFormat * CreateFileFormat3DL()
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatCC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCC.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include "fileformats/cdl/CDLParser.h"
 #include "fileformats/cdl/CDLWriter.h"
@@ -166,3 +168,4 @@ FileFormat * CreateFileFormatCC()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatCCC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCCC.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-#include <map>
+#include "transforms/FileTransform.h"
 
-#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
+#include <map>
 
 #include "fileformats/cdl/CDLParser.h"
 #include "fileformats/cdl/CDLWriter.h"
@@ -11,7 +13,6 @@
 #include "fileformats/xmlutils/XMLWriterUtils.h"
 #include "fileformats/FormatMetadata.h"
 #include "transforms/CDLTransform.h"
-#include "transforms/FileTransform.h"
 #include "OpBuilders.h"
 #include "ParseUtils.h"
 
@@ -257,3 +258,4 @@ FileFormat * CreateFileFormatCCC()
     return new LocalFileFormat();
 }
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatCDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCDL.cpp
@@ -25,10 +25,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include <map>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/cdl/CDLParser.h"
 #include "fileformats/cdl/CDLWriter.h"
@@ -290,3 +291,4 @@ FileFormat * CreateFileFormatCDL()
 
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <algorithm>
 #include <cassert>
@@ -11,7 +14,6 @@
 #include <iterator>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "MathUtils.h"
@@ -925,3 +927,4 @@ FileFormat * CreateFileFormatCSP()
     return new LocalFileFormat();
 }
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
+
 #include <cstdio>
 #include <iostream>
 #include <fstream>
@@ -8,7 +12,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "expat.h"
 #include "fileformats/ctf/CTFTransform.h"
@@ -1578,3 +1581,4 @@ FileFormat * CreateFileFormatCLF()
 
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <algorithm>
 #include <cmath>
@@ -10,7 +13,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "fileformats/FileFormatUtils.h"
@@ -772,3 +774,4 @@ FileFormat * CreateFileFormatDiscreet1DL()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -17,6 +17,9 @@
         - Add support for 'Sampling' tag
 
 */
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <algorithm>
 #include <cmath>
@@ -27,7 +30,6 @@
 #include <string>
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "MathUtils.h"
@@ -886,3 +888,4 @@ FileFormat * CreateFileFormatHDL()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <sstream>
 #include <fstream>
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Logging.h"
 #include "fileformats/FileFormatUtils.h"
@@ -910,3 +912,4 @@ std::string GetProfileDescriptionFromICCProfile(const char * ICCProfileFilepath)
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut1d/Lut1DOp.h"
@@ -564,3 +567,5 @@ FileFormat * CreateFileFormatIridasCube()
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include <cstdio>
 #include <cstring>
 #include <iterator>
 #include <algorithm>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut1d/Lut1DOp.h"
@@ -323,3 +324,4 @@ FileFormat * CreateFileFormatIridasItx()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <cstdio>
 #include <cstring>
@@ -7,7 +10,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "expat.h"
 #include "fileformats/FileFormatUtils.h"
@@ -580,3 +582,4 @@ FileFormat * CreateFileFormatIridasLook()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatPandora.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatPandora.cpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 #include <cstdio>
 #include <iostream>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "fileformats/FileFormatUtils.h"
@@ -312,3 +314,4 @@ FileFormat * CreateFileFormatPandora()
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
 
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut1d/Lut1DOp.h"
@@ -786,3 +788,4 @@ FileFormat * CreateFileFormatResolveCube()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut1d/Lut1DOp.h"
@@ -459,3 +462,4 @@ FileFormat * CreateFileFormatSpi1D()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <cstdio>
 #include <sstream>
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut3d/Lut3DOp.h"
@@ -338,3 +340,4 @@ FileFormat * CreateFileFormatSpi3D()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include <cstdio>
 #include <cstring>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/matrix/MatrixOp.h"
 #include "ParseUtils.h"
@@ -168,3 +169,4 @@ FileFormat * CreateFileFormatSpiMtx()
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <algorithm>
 #include <cstdio>
@@ -7,7 +10,6 @@
 #include <iostream>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut1d/Lut1DOp.h"
@@ -399,3 +401,4 @@ FileFormat * CreateFileFormatTruelight()
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatUtils.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatUtils.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-
 #include "fileformats/FileFormatUtils.h"
+
+#if OCIO_LUT_SUPPORT
 
 #include "Logging.h"
 
@@ -65,3 +66,4 @@ void LogWarningInterpolationNotUsed(Interpolation interp, const FileTransform & 
     LogWarning(oss.str());
 }
 } // OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/FileFormatUtils.h
+++ b/src/OpenColorIO/fileformats/FileFormatUtils.h
@@ -7,11 +7,14 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "ops/lut1d/Lut1DOpData.h"
 #include "ops/lut3d/Lut3DOpData.h"
 
 namespace OCIO_NAMESPACE
 {
+
 Lut1DOpDataRcPtr HandleLUT1D(const Lut1DOpDataRcPtr & fileLut1D,
                              Interpolation fileInterp,
                              bool & fileInterpUsed);
@@ -21,6 +24,9 @@ Lut3DOpDataRcPtr HandleLUT3D(const Lut3DOpDataRcPtr & fileLut3D,
                              bool & fileInterpUsed);
 
 void LogWarningInterpolationNotUsed(Interpolation interp, const FileTransform & fileTransform);
+
+
 } // OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif // INCLUDED_OCIO_FILEFORMAT_UTILS_H

--- a/src/OpenColorIO/fileformats/FileFormatVF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatVF.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/FileFormatUtils.h"
 #include "ops/lut3d/Lut3DOp.h"
@@ -320,3 +322,4 @@ FileFormat * CreateFileFormatVF()
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include "transforms/CDLTransform.h"
+
+#if OCIO_LUT_SUPPORT
+
 #include <sstream>
 
 #include "expat.h"
@@ -8,7 +12,6 @@
 #include "fileformats/cdl/CDLReaderHelper.h"
 #include "fileformats/xmlutils/XMLReaderHelper.h"
 #include "fileformats/xmlutils/XMLReaderUtils.h"
-#include "transforms/CDLTransform.h"
 #include "Platform.h"
 
 namespace OCIO_NAMESPACE
@@ -1015,3 +1018,5 @@ bool CDLParser::isCCC() const
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.cpp
@@ -2,6 +2,9 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "fileformats/cdl/CDLReaderHelper.h"
+
+#if OCIO_LUT_SUPPORT
+
 #include "fileformats/xmlutils/XMLReaderUtils.h"
 
 namespace OCIO_NAMESPACE
@@ -85,3 +88,5 @@ void CDLReaderColorCorrectionElt::appendMetadata(const std::string & name, const
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.h
+++ b/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.h
@@ -3,10 +3,13 @@
 
 #ifndef INCLUDED_OCIO_FILEFORMATS_CDL_CDLREADERHELPER_H
 #define INCLUDED_OCIO_FILEFORMATS_CDL_CDLREADERHELPER_H
+#include "transforms/CDLTransform.h"
+
+#if OCIO_LUT_SUPPORT
+
 
 #include "fileformats/xmlutils/XMLReaderHelper.h"
 #include "Op.h"
-#include "transforms/CDLTransform.h"
 
 namespace OCIO_NAMESPACE
 {
@@ -213,5 +216,6 @@ public:
 };
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/fileformats/cdl/CDLWriter.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLWriter.cpp
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include "transforms/CDLTransform.h"
+
+#if OCIO_LUT_SUPPORT
+
 #include <sstream>
 
 #include "fileformats/cdl/CDLWriter.h"
 #include "fileformats/xmlutils/XMLReaderUtils.h"
 #include "fileformats/xmlutils/XMLWriterUtils.h"
 #include "ParseUtils.h"
-#include "transforms/CDLTransform.h"
 #include "transforms/FileTransform.h"
 
 namespace OCIO_NAMESPACE
@@ -112,3 +115,4 @@ void Write(XmlFormatter & fmt, const ConstCDLTransformRcPtr & cdl)
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
@@ -12,6 +12,8 @@
 #include "Platform.h"
 #include "utils/StringUtils.h"
 
+#if OCIO_LUT_SUPPORT
+
 
 namespace OCIO_NAMESPACE
 {
@@ -4915,3 +4917,4 @@ const OpDataRcPtr CTFReaderReferenceElt::getOp() const
 
 } // namespace OCIO_NAMESPACE
 
+#endif OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.h
+++ b/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.h
@@ -23,6 +23,8 @@
 #include "ops/range/RangeOpData.h"
 #include "ops/reference/ReferenceOpData.h"
 
+#if OCIO_LUT_SUPPORT
+
 namespace OCIO_NAMESPACE
 {
 
@@ -311,8 +313,8 @@ public:
     enum Type
     {
         CDLType = 0,
-        Lut1DType,
-        Lut3DType,
+        Lut1DType, //TODO Nano: remove?
+        Lut3DType,//TODO Nano: remove?
         MatrixType,
         RangeType,
         // CTF types.
@@ -324,8 +326,8 @@ public:
         GradingPrimaryType,
         GradingRGBCurveType,
         GradingToneType,
-        InvLut1DType,
-        InvLut3DType,
+        InvLut1DType,//TODO Nano: remove?
+        InvLut3DType,//TODO Nano: remove?
         LogType,
         ReferenceType,
 
@@ -1214,5 +1216,6 @@ public:
 };
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
@@ -28,6 +28,8 @@
 #include "Platform.h"
 #include "transforms/CDLTransform.h"
 
+#if OCIO_LUT_SUPPORT
+
 namespace OCIO_NAMESPACE
 {
 
@@ -1870,7 +1872,7 @@ void LogWriter::writeContent() const
 
 
 ///////////////////////////////////////////////////////////////////////////////
-
+#if OCIO_LUT_SUPPORT
 class Lut1DWriter : public OpWriter
 {
 public:
@@ -2105,6 +2107,7 @@ void Lut3DWriter::writeContent() const
 
     m_formatter.writeEndTag(TAG_ARRAY);
 }
+#endif //OCIO_LUT_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -2772,3 +2775,4 @@ void TransformWriter::writeOps(const CTFVersion & version) const
 }
 
 } // namespace OCIO_NAMESPACE
+#endif OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/xmlutils/XMLReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLReaderHelper.cpp
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include "fileformats/xmlutils/XMLReaderHelper.h"
+
+#if OCIO_LUT_SUPPORT
+
 #include <sstream>
 
-#include "fileformats/xmlutils/XMLReaderHelper.h"
 #include "fileformats/xmlutils/XMLReaderUtils.h"
 #include "Logging.h"
 #include "ParseUtils.h"
@@ -282,3 +285,4 @@ void XmlReaderSaturationElt::setRawData(const char* str, size_t len, unsigned in
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/xmlutils/XMLReaderHelper.h
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLReaderHelper.h
@@ -386,18 +386,21 @@ public:
         }
     }
 
-    virtual const CDLOpDataRcPtr & getCDL() const = 0;
 
     void setIsSlopeInit(bool status) { m_isSlopeInit = status; }
     void setIsOffsetInit(bool status) { m_isOffsetInit = status; }
     void setIsPowerInit(bool status) { m_isPowerInit = status; }
 
+#if OCIO_LUT_SUPPORT
+
+    virtual const CDLOpDataRcPtr & getCDL() const = 0;
     void appendMetadata(const std::string & /* name */, const std::string & value) override
     {
         // Add description to parent and override name.
         FormatMetadataImpl item(METADATA_SOP_DESCRIPTION, value);
         getCDL()->getFormatMetadata().getChildrenElements().push_back(item);
     }
+#endif //OCIO_LUT_SUPPORT
 
 private:
     XmlReaderSOPNodeBaseElt() = delete;
@@ -450,6 +453,7 @@ public:
     {
     }
 
+#if OCIO_LUT_SUPPORT
     virtual const CDLOpDataRcPtr & getCDL() const = 0;
 
     void appendMetadata(const std::string & /* name */, const std::string & value) override
@@ -458,6 +462,7 @@ public:
         FormatMetadataImpl item(METADATA_SAT_DESCRIPTION, value);
         getCDL()->getFormatMetadata().getChildrenElements().push_back(item);
     }
+#endif //OCIO_LUT_SUPPORT
 
 
 private:

--- a/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.cpp
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.cpp
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include "fileformats/xmlutils/XMLReaderUtils.h"
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 
-#include "fileformats/xmlutils/XMLReaderUtils.h"
 
 namespace OCIO_NAMESPACE
 {
@@ -114,3 +117,4 @@ void FindSubString(const char * str, size_t length,
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.h
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.h
@@ -4,13 +4,15 @@
 #ifndef INCLUDED_OCIO_FILEFORMATS_XML_XMLREADERUTILS_H
 #define INCLUDED_OCIO_FILEFORMATS_XML_XMLREADERUTILS_H
 
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 
 #include <type_traits>
 #include <string>
 #include <sstream>
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "MathUtils.h"
 #include "utils/StringUtils.h"
@@ -244,5 +246,6 @@ std::vector<T> GetNumbers(const char * str, size_t len)
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/cdl/CDLOp.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOp.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
 
 #include <cstring>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "GpuShaderUtils.h"
@@ -266,3 +268,4 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/cdl/CDLOp.h
+++ b/src/OpenColorIO/ops/cdl/CDLOp.h
@@ -4,10 +4,11 @@
 
 #ifndef INCLUDED_OCIO_CDL_H
 #define INCLUDED_OCIO_CDL_H
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Op.h"
 #include "ops/cdl/CDLOpData.h"
@@ -35,5 +36,6 @@ void CreateCDLOp(OpRcPtrVec & ops,
 void CreateCDLTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op);
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
 
 #include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "HashUtils.h"
@@ -253,3 +255,5 @@ void BuildLut1DOp(OpRcPtrVec & ops,
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOp.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOp.h
@@ -5,10 +5,12 @@
 #ifndef INCLUDED_OCIO_LUT1DOP_H
 #define INCLUDED_OCIO_LUT1DOP_H
 
-#include <vector>
-
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
+
+#include <vector>
 #include "ops/lut1d/Lut1DOpData.h"
 
 namespace OCIO_NAMESPACE
@@ -28,5 +30,7 @@ void CreateLut1DOp(OpRcPtrVec & ops,
 void CreateLut1DTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op);
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <math.h>
 #include <memory>
 #include <stdint.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "MathUtils.h"
@@ -1754,3 +1757,4 @@ ConstOpCPURcPtr GetLut1DRenderer(ConstLut1DOpDataRcPtr & lut, BitDepth inBD, Bit
 
 } // namespace OCIO_NAMESPACE
 
+#endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.h
@@ -5,6 +5,7 @@
 #define INCLUDED_OCIO_LUT1DOP_CPU_H
 
 #include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include "ops/lut1d/Lut1DOpData.h"
 
@@ -15,4 +16,5 @@ ConstOpCPURcPtr GetLut1DRenderer(ConstLut1DOpDataRcPtr & lut, BitDepth in, BitDe
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT
 #endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut1DOpCPU_AVX.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX
 
 #include <immintrin.h>
@@ -197,3 +199,4 @@ Lut1DOpCPUApplyFunc * AVXGetLut1DApplyFunc(BitDepth inBD, BitDepth outBD)
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX2.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX2.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut1DOpCPU_AVX2.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX2
 
 #include <immintrin.h>
@@ -175,3 +177,4 @@ Lut1DOpCPUApplyFunc * AVX2GetLut1DApplyFunc(BitDepth inBD, BitDepth outBD)
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX2
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX2.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX2.h
@@ -6,6 +6,9 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
+
 #include "CPUInfo.h"
 
 typedef void (Lut1DOpCPUApplyFunc)(const float *, const float *, const float *, int, const void *, void *, long);
@@ -21,3 +24,4 @@ Lut1DOpCPUApplyFunc * AVX2GetLut1DApplyFunc(BitDepth inBD, BitDepth outBD);
 #endif // OCIO_USE_AVX2
 
 #endif /* INCLUDED_OCIO_LUT1DOP_CPU_AVX2_H */
+#endif OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX512.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_AVX512.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut1DOpCPU_AVX512.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX512
 
 #include <immintrin.h>
@@ -148,3 +150,4 @@ Lut1DOpCPUApplyFunc * AVX512GetLut1DApplyFunc(BitDepth inBD, BitDepth outBD)
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX512
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_SSE2.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU_SSE2.cpp
@@ -3,6 +3,9 @@
 
 #include "Lut1DOpCPU_SSE2.h"
 
+#if OCIO_LUT_SUPPORT
+
+
 #if OCIO_USE_SSE2
 
 #include <string.h>
@@ -206,3 +209,4 @@ Lut1DOpCPUApplyFunc * SSE2GetLut1DApplyFunc(BitDepth inBD, BitDepth outBD)
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_SSE2
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <sstream>
 #include <string.h>
-
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "HashUtils.h"
@@ -1123,3 +1125,5 @@ bool operator==(const Lut1DOpData & lhs, const Lut1DOpData & rhs)
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -6,6 +6,9 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
+
 #include "Op.h"
 #include "ops/OpArray.h"
 #include "PrivateTypes.h"
@@ -275,5 +278,7 @@ bool operator==(const Lut1DOpData & lhs, const Lut1DOpData & rhs);
 Lut1DOpDataRcPtr MakeFastLut1DFromInverse(ConstLut1DOpDataRcPtr & lut);
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.cpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <iterator>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "GpuShaderUtils.h"
 #include "MathUtils.h"
@@ -388,3 +391,4 @@ void GetLut1DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
 
 } // namespace OCIO_NAMESPACE
 
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <sstream>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "GpuShaderUtils.h"
@@ -261,3 +264,4 @@ void BuildLut3DOp(OpRcPtrVec & ops,
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOp.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOp.h
@@ -7,6 +7,8 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "ops/lut3d/Lut3DOpData.h"
 
 namespace OCIO_NAMESPACE
@@ -58,5 +60,6 @@ void CreateLut3DOp(OpRcPtrVec & ops,
 void CreateLut3DTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op);
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <math.h>
 #include <stdint.h>
 #include <vector>
-
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "BitDepthUtils.h"
 #include "MathUtils.h"
@@ -1763,3 +1765,5 @@ ConstOpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.h
@@ -6,6 +6,8 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "Op.h"
 #include "ops/lut3d/Lut3DOpData.h"
 
@@ -15,5 +17,6 @@ namespace OCIO_NAMESPACE
 ConstOpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut);
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut3DOpCPU_AVX.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX
 
 #include "AVX.h"
@@ -325,3 +327,4 @@ void applyTetrahedralAVX(const float *lut3d, int dim, const float *src, float *d
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX2.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX2.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut3DOpCPU_AVX2.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX2
 
 #include <immintrin.h>
@@ -278,3 +280,4 @@ void applyTetrahedralAVX2(const float *lut3d, int dim, const float *src, float *
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX2
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX512.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_AVX512.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "Lut3DOpCPU_AVX512.h"
+
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_AVX512
 
 #include <immintrin.h>
@@ -257,3 +259,4 @@ void applyTetrahedralAVX512(const float *lut3d, int dim, const float *src, float
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_AVX512
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_SSE2.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_SSE2.cpp
@@ -3,6 +3,7 @@
 
 #include "Lut3DOpCPU_SSE2.h"
 
+#if OCIO_LUT_SUPPORT
 #if OCIO_USE_SSE2
 
 #include "SSE2.h"
@@ -319,3 +320,4 @@ void applyTetrahedralSSE2(const float *lut3d, int dim, const float *src, float *
 } // OCIO_NAMESPACE
 
 #endif // OCIO_USE_SSE2
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_SSE2.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU_SSE2.h
@@ -6,6 +6,8 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "CPUInfo.h"
 
 #if OCIO_USE_SSE2
@@ -19,3 +21,4 @@ void applyTetrahedralSSE2(const float *lut3d, int dim, const float *src, float *
 #endif // OCIO_USE_SSE2
 
 #endif /* INCLUDED_OCIO_LUT3DOP_CPU_SSE2_H */
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-#include <sstream>
-
 #include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
+#include <sstream>
 
 #include "BitDepthUtils.h"
 #include "HashUtils.h"
@@ -500,3 +502,5 @@ bool operator==(const Lut3DOpData & lhs, const Lut3DOpData & rhs)
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
@@ -4,9 +4,11 @@
 #ifndef INCLUDED_OCIO_LUT3DOPDATA_H
 #define INCLUDED_OCIO_LUT3DOPDATA_H
 
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
+
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Op.h"
 #include "ops/OpArray.h"
@@ -145,5 +147,6 @@ bool operator==(const Lut3DOpData & lhs, const Lut3DOpData & rhs);
 Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut);
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-#include <algorithm>
-
 #include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
+#include <algorithm>
 
 #include "GpuShaderUtils.h"
 #include "MathUtils.h"
@@ -245,3 +247,4 @@ void GetLut3DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLut3DO
 
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/ops/noop/NoOps.cpp
+++ b/src/OpenColorIO/ops/noop/NoOps.cpp
@@ -172,6 +172,7 @@ bool GetGpuAllocation(AllocationData & allocation,
 }
 }
 
+#if OCIO_LUT_SUPPORT
 OpRcPtrVec Create3DLut(const OpRcPtrVec & ops, unsigned edgelen)
 {
     if(ops.size()==0) return OpRcPtrVec();
@@ -204,6 +205,7 @@ OpRcPtrVec Create3DLut(const OpRcPtrVec & ops, unsigned edgelen)
     CreateLut3DOp(newOps, lut, TRANSFORM_DIR_FORWARD);
     return newOps;
 }
+#endif //OCIO_LUT_SUPPORT
 
 void PartitionGPUOps(OpRcPtrVec & gpuPreOps,
                         OpRcPtrVec & gpuLatticeOps,

--- a/src/OpenColorIO/ops/noop/NoOps.h
+++ b/src/OpenColorIO/ops/noop/NoOps.h
@@ -13,9 +13,10 @@
 
 namespace OCIO_NAMESPACE
 {
-
+#if OCIO_LUT_SUPPORT
 // Create a 3D LUT from an arbitrary list of ops.
 OpRcPtrVec Create3DLut(const OpRcPtrVec & ops, unsigned edgelen);
+#endif //OCIO_LUT_SUPPORT
 
 // Partition an opvec into 3 segments for GPU Processing
 //

--- a/src/OpenColorIO/ops/range/RangeOp.cpp
+++ b/src/OpenColorIO/ops/range/RangeOp.cpp
@@ -114,6 +114,7 @@ bool RangeOp::canCombineWith(ConstOpRcPtr & op2) const
     if (range1->isIdentity())
     {
         // If op is LUT range op can be removed.
+#if OCIO_LUT_SUPPORT
         if (type2 == OpData::Lut1DType)
         {
             auto lut = OCIO_DYNAMIC_POINTER_CAST<const Lut1DOpData>(opData2);
@@ -131,6 +132,7 @@ bool RangeOp::canCombineWith(ConstOpRcPtr & op2) const
                 return true;
             }
         }
+#endif //OCIO_LUT_SUPPORT
     }
 
     if (type2 == OpData::RangeType)

--- a/src/OpenColorIO/transforms/CDLTransform.cpp
+++ b/src/OpenColorIO/transforms/CDLTransform.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 #include <fstream>
 #include <sstream>
 #include <string.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "fileformats/cdl/CDLParser.h"
 #include "Logging.h"
@@ -387,3 +388,4 @@ std::ostream & operator<< (std::ostream & os, const CDLTransform & t)
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/CDLTransform.h
+++ b/src/OpenColorIO/transforms/CDLTransform.h
@@ -5,10 +5,13 @@
 #ifndef INCLUDED_OCIO_CDLTRANSFORM_H
 #define INCLUDED_OCIO_CDLTRANSFORM_H
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <map>
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/cdl/CDLOpData.h"
 
@@ -83,5 +86,8 @@ private:
 };
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT
+
 
 #endif

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <fstream>
 #include <map>
@@ -11,7 +15,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Caching.h"
 #include "FileTransform.h"
@@ -988,3 +991,4 @@ void BuildFileTransformOps(OpRcPtrVec & ops,
 }
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/FileTransform.h
+++ b/src/OpenColorIO/transforms/FileTransform.h
@@ -5,10 +5,12 @@
 #ifndef INCLUDED_OCIO_FILETRANSFORM_H
 #define INCLUDED_OCIO_FILETRANSFORM_H
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
 
 #include <map>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Op.h"
 #include "ops/noop/NoOps.h"
@@ -185,4 +187,5 @@ static constexpr char FILEFORMAT_COLOR_DECISION_LIST[]         = "ColorDecisionL
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT
 #endif

--- a/src/OpenColorIO/transforms/GroupTransform.cpp
+++ b/src/OpenColorIO/transforms/GroupTransform.cpp
@@ -111,6 +111,7 @@ void GroupTransformImpl::prependTransform(TransformRcPtr transform) noexcept
     m_vec.insert(m_vec.begin(), transform);
 }
 
+#if OCIO_LUT_SUPPORT
 void GroupTransformImpl::write(const ConstConfigRcPtr & config,
                                const char * formatName,
                                std::ostream & os) const
@@ -152,6 +153,29 @@ const char * GroupTransform::GetFormatExtensionByIndex(int index) noexcept
 {
     return FormatRegistry::GetInstance().getFormatExtensionByIndex(FORMAT_CAPABILITY_WRITE, index);
 }
+#else
+void GroupTransformImpl::write(const ConstConfigRcPtr& config,
+	const char* formatName,
+	std::ostream& os) const
+{
+	throw Exception("LUT support is OFF.");
+}
+
+int GroupTransform::GetNumWriteFormats() noexcept
+{
+    return 0;
+}
+
+const char* GroupTransform::GetFormatNameByIndex(int index) noexcept
+{
+	return nullptr;
+}
+
+const char* GroupTransform::GetFormatExtensionByIndex(int index) noexcept
+{
+	return nullptr;
+}
+#endif //OCIO_LUT_SUPPORT
 
 std::ostream & operator<< (std::ostream & os, const GroupTransform & groupTransform)
 {

--- a/src/OpenColorIO/transforms/Lut1DTransform.cpp
+++ b/src/OpenColorIO/transforms/Lut1DTransform.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <cstring>
 #include <sstream>
 #include <vector>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "transforms/Lut1DTransform.h"
 
@@ -225,3 +228,4 @@ std::ostream & operator<< (std::ostream & os, const Lut1DTransform & t)
 
 } // namespace OCIO_NAMESPACE
 
+#endif //#if OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/Lut1DTransform.h
+++ b/src/OpenColorIO/transforms/Lut1DTransform.h
@@ -7,6 +7,8 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "ops/lut1d/Lut1DOpData.h"
 
 
@@ -67,4 +69,7 @@ private:
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT
+
 #endif  // INCLUDED_OCIO_LUT1DTRANSFORM_H
+

--- a/src/OpenColorIO/transforms/Lut3DTransform.cpp
+++ b/src/OpenColorIO/transforms/Lut3DTransform.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_LUT_SUPPORT
+
 #include <algorithm>
 #include <cstring>
 #include <sstream>
 #include <vector>
-
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "transforms/Lut3DTransform.h"
 
@@ -219,3 +221,4 @@ std::ostream & operator<< (std::ostream & os, const Lut3DTransform & t)
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/Lut3DTransform.h
+++ b/src/OpenColorIO/transforms/Lut3DTransform.h
@@ -7,6 +7,8 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
+
 #include "ops/lut3d/Lut3DOpData.h"
 
 
@@ -65,3 +67,4 @@ private:
 } // namespace OCIO_NAMESPACE
 
 #endif  // INCLUDED_OCIO_LUT3DTRANSFORM_H
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -73,8 +73,9 @@ static constexpr double nonuniform_LUT[lutSize * 2]
      0.600000000000000, -0.926545676714876
 };
 
-void GenerateOps(OpRcPtrVec & ops)
+void GenerateOps(OpRcPtrVec& ops)
 {
+#if OCIO_LUT_SUPPORT
     // Note that in CTL, the matrices are stored transposed.
     static constexpr double CDD_TO_CID[4 * 4]
     {
@@ -133,7 +134,11 @@ void GenerateOps(OpRcPtrVec & ops)
     };
 
     // Convert Relative Exposure values to ACES values.
-    CreateMatrixOp(ops, &EXP_TO_ACES[0], TRANSFORM_DIR_FORWARD);            
+    CreateMatrixOp(ops, &EXP_TO_ACES[0], TRANSFORM_DIR_FORWARD);          
+#else
+#pragma message("Needs LUT-free implementation")
+#endif //OCIO_LUT_SUPPORT
+
 }
 
 }  // namespace ADX_to_ACES
@@ -429,6 +434,7 @@ void Generate_nit_normalization_ops(OpRcPtrVec & ops, double nit_level)
 
 void Generate_roll_white_d60_ops(OpRcPtrVec & ops)
 {
+#if OCIO_LUT_SUPPORT
     auto GenerateLutValues = [](double in) -> float
     {
         const double new_wht = 0.918;
@@ -459,10 +465,14 @@ void Generate_roll_white_d60_ops(OpRcPtrVec & ops)
     };
 
     CreateHalfLut(ops, GenerateLutValues);
+#else
+#   pragma message("Needs lut-free implementation")
+#endif //OCIO_LUT_SUPPORT
 }
 
 void Generate_roll_white_d65_ops(OpRcPtrVec & ops)
 {
+#if OCIO_LUT_SUPPORT
     auto GenerateLutValues = [](double in) -> float
     {
         const double new_wht = 0.908;
@@ -493,6 +503,9 @@ void Generate_roll_white_d65_ops(OpRcPtrVec & ops)
     };
 
     CreateHalfLut(ops, GenerateLutValues);
+#else
+#   pragma message("Needs lut-free implementation")
+#endif //OCIO_LUT_SUPPORT
 }
 
 }  // namespace ACES_OUTPUT
@@ -571,6 +584,8 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
                             ACEScct_to_ACES2065_1_Functor);
     }
     {
+#if OCIO_LUT_SUPPORT
+
         auto ACEScc_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
         {
             auto GenerateLutValues = [](double input) -> float
@@ -619,6 +634,9 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
         registry.addBuiltin("ACEScc_to_ACES2065-1", 
                             "Convert ACEScc to ACES2065-1",
                             ACEScc_to_ACES2065_1_Functor);
+#else
+#   pragma message("Needs lut-free implementation")
+#endif //OCIO_LUT_SUPPORT
     }
     {
         auto ACEScg_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)

--- a/src/OpenColorIO/transforms/builtins/AppleCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/AppleCameras.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 
 #include <cmath>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/matrix/MatrixOp.h"
 #include "transforms/builtins/AppleCameras.h"
@@ -45,6 +46,7 @@ void GenerateAppleLogToLinearOps(OpRcPtrVec & ops)
         }
     };
 
+    //TODO Nano: do we need this? /coz
     CreateHalfLut(ops, GenerateLutValues);
 
 }
@@ -90,3 +92,5 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
 } // namespace CAMERA
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/builtins/AppleCameras.h
+++ b/src/OpenColorIO/transforms/builtins/AppleCameras.h
@@ -5,9 +5,8 @@
 #ifndef INCLUDED_OCIO_APPLE_CAMERAS_H
 #define INCLUDED_OCIO_APPLE_CAMERAS_H
 
-
 #include <OpenColorIO/OpenColorIO.h>
-
+#if OCIO_LUT_SUPPORT
 
 namespace OCIO_NAMESPACE
 {
@@ -27,5 +26,6 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
 } // namespace CAMERA
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif // INCLUDED_OCIO_APPLE_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -110,9 +110,11 @@ void BuiltinTransformRegistryImpl::registerAll() noexcept
     ACES::RegisterAll(*this);
 
     // Camera support.
+#if OCIO_LUT_SUPPORT
     CAMERA::APPLE::RegisterAll(*this);
-    CAMERA::ARRI::RegisterAll(*this);
     CAMERA::CANON::RegisterAll(*this);
+#endif //OCIO_LUT_SUPPORT
+	CAMERA::ARRI::RegisterAll(*this);
     CAMERA::PANASONIC::RegisterAll(*this);
     CAMERA::RED::RegisterAll(*this);
     CAMERA::SONY::RegisterAll(*this);

--- a/src/OpenColorIO/transforms/builtins/CanonCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/CanonCameras.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
 
+#if OCIO_LUT_SUPPORT
 
 #include <cmath>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/matrix/MatrixOp.h"
 #include "transforms/builtins/ACES.h"
@@ -134,3 +135,5 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
 } // namespace CAMERA
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_LUT_SUPPORT

--- a/src/OpenColorIO/transforms/builtins/CanonCameras.h
+++ b/src/OpenColorIO/transforms/builtins/CanonCameras.h
@@ -7,6 +7,7 @@
 
 
 #include <OpenColorIO/OpenColorIO.h>
+#if OCIO_LUT_SUPPORT
 
 
 namespace OCIO_NAMESPACE
@@ -27,5 +28,6 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
 } // namespace CAMERA
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_LUT_SUPPORT
 
 #endif // INCLUDED_OCIO_CANON_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/Displays.cpp
+++ b/src/OpenColorIO/transforms/builtins/Displays.cpp
@@ -33,6 +33,7 @@ static constexpr double c1 = c3 - c2 + 1.;
 
 void GeneratePQToLinearOps(OpRcPtrVec & ops)
 {
+#if OCIO_LUT_SUPPORT
     auto GenerateLutValues = [](double input) -> float
     {
         const double N = std::max(0., input);
@@ -44,11 +45,16 @@ void GeneratePQToLinearOps(OpRcPtrVec & ops)
         return float(L);
     };
 
+    // TODO Nano: do we need this? /coz
     CreateLut(ops, 4096, GenerateLutValues);
+#else
+#   pragma message("Needs lut-free implementation")
+#endif //OCIO_LUT_SUPPORT
 }
 
 void GenerateLinearToPQOps(OpRcPtrVec & ops)
 {
+#if OCIO_LUT_SUPPORT
     auto GenerateLutValues = [](double input) -> float
     {
         // Input is in nits/100, convert to [0,1], where 1 is 10000 nits.
@@ -60,7 +66,11 @@ void GenerateLinearToPQOps(OpRcPtrVec & ops)
         return float(N);
     };
 
+	// TODO Nano: do we need this? /coz
     CreateHalfLut(ops, GenerateLutValues);
+#else
+#   pragma message("Needs lut-free implementation")
+#endif //OCIO_LUT_SUPPORT
 }
 
 } // ST_2084
@@ -285,6 +295,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
                             CIE_XYZ_D65_to_ST2084_P3_D65_Functor);
     }
 
+#if OCIO_LUT_SUPPORT
     {
         auto CIE_XYZ_D65_to_REC2100_HLG_1000nit_Functor = [](OpRcPtrVec & ops)
         {
@@ -337,6 +348,10 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
                             "Convert CIE XYZ (D65 white) to Rec.2100-HLG, 1000 nit",
                             CIE_XYZ_D65_to_REC2100_HLG_1000nit_Functor);
     }
+#else
+#   pragma message("Needs lut-free implementation")
+#endif OCIO_LUT_SUPPORT
+
 
 }
 

--- a/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
@@ -12,6 +12,7 @@
 
 namespace OCIO_NAMESPACE
 {
+#if OCIO_LUT_SUPPORT
 
 double Interpolate1D(unsigned lutSize, const double * lutValues, double in)
 {
@@ -139,5 +140,6 @@ void CreateHalfLut(OpRcPtrVec & ops, std::function<float(double)> lutValueGenera
 
     CreateLut1DOp(ops, lut, TRANSFORM_DIR_FORWARD);
 }
+#endif //OCIO_LUT_SUPPORT
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/OpHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/OpHelpers.h
@@ -13,6 +13,8 @@
 namespace OCIO_NAMESPACE
 {
 
+#if OCIO_LUT_SUPPORT
+
 // Linearly interpolate a single input value through a non-uniformly spaced LUT.
 // The lutValues are ordered as: [in0, out0, in1, out1, in2, out2, ...].
 // The lutSize is the number of in/out pairs, so there are 2*lutSize lutValues.
@@ -36,6 +38,9 @@ void CreateLut(OpRcPtrVec & ops,
 // However NaNs are mapped to 0 and +/-Inf is mapped to +/-HALF_MAX.
 void CreateHalfLut(OpRcPtrVec & ops,
                    std::function<float(double)> lutValueGenerator);
+
+#endif //OCIO_LUT_SUPPORT
+
 
 } // namespace OCIO_NAMESPACE
 


### PR DESCRIPTION
Adding options to turn off various features to reduce OCIO size
- OCIO_LUT_SUPPORT
- OCIO_ARCHIVE_SUPPORT 
- OCIO_USE_HALF_LOOKUP_TABLE

When all are turned off, the dll size goes down from 4468 KB to 2381 KB
